### PR TITLE
Fix for grabbing the correct presentingViewController in iOS 7.

### DIFF
--- a/Example/URBNCarousel/SourceViewController.m
+++ b/Example/URBNCarousel/SourceViewController.m
@@ -52,18 +52,23 @@
     self.transitionController = [[URBNCarouselTransitionController alloc] init];
 }
 
-
 #pragma mark - Convenience
 - (void)presentGalleryController
 {
     DestinationViewController *vc = [[DestinationViewController alloc] initWithTransitionController:self.transitionController];
     vc.transitioningDelegate = self.transitionController;
     
+    //  In some cases the iOS will use your rootViewController as the presenting view controller - from documentation on presenting view controllers -
+    //  "When a view controller is presented, iOS searches for a presentation context. It starts at the presenting view controller by reading its definesPresentationContext property. If the value of this property is YES, then the presenting view controller defines the presentation context. Otherwise, it continues up through the view controller hierarchy until a view controller returns YES or until it reaches the window’s root view controller."
+    //  iOS8 allows this property to be set on iPhone view controllers, BUT iOS7 will ignore it.  The transition controller however has a check built in to set the correct presenting view controller in the event of iOS7.
+    if ([self respondsToSelector:@selector(setDefinesPresentationContext:)]) {
+        self.definesPresentationContext = YES;
+    }
+    
     [self presentViewController:vc animated:YES completion:^{
         [self.collectionView registerForSynchronizationWithCollectionView:vc.collectionView];
     }];
 }
-
 
 #pragma mark - GalleryTransitioning
 - (void)willBeginGalleryTransitionWithImageView:(UIImageView *)imageView isToVC:(BOOL)isToVC

--- a/Pod/Classes/URBNCarouselTransitionController.m
+++ b/Pod/Classes/URBNCarouselTransitionController.m
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSUInteger, URBNCarouselTransitionState) {
 @property(nonatomic, assign) CGFloat startScale;
 @property(nonatomic, assign) CGFloat springCompletionSpeed;
 @property(nonatomic, assign) CGFloat completionSpeed;
+@property(nonatomic, strong) UIViewController *sourceViewController;
 
 @end
 
@@ -55,6 +56,11 @@ typedef NS_ENUM(NSUInteger, URBNCarouselTransitionState) {
 - (UIViewController<URBNCarouselTransitioning> *)trueContextViewControllerFromContext:(id <UIViewControllerContextTransitioning>)transitionContext withKey:(NSString *)key
 {
     UIViewController<URBNCarouselTransitioning> *vc = (UIViewController<URBNCarouselTransitioning> *)[transitionContext viewControllerForKey:key];
+    
+    // Unless the view controller who called presentViewController sets definePresentationContext = YES; , the vc will be the rootViewController, who will not conform to the URBNTransitioning protocol.  In this case the trueContextViewController should be the source set by animationControllerForPresentedController.
+    if (![vc conformsToProtocol:@protocol(URBNCarouselTransitioning)]) {
+        vc = (UIViewController<URBNCarouselTransitioning> *)self.sourceViewController;
+    }
     
     // Here we're using topViewController directly to account for really custom transitions.
     // If you have an un-traditional viewController stack then your custom containerVC can override this
@@ -381,6 +387,8 @@ typedef NS_ENUM(NSUInteger, URBNCarouselTransitionState) {
 #pragma mark - UIViewControllerTransitioningDelegate
 - (id <UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented presentingController:(UIViewController *)presenting sourceController:(UIViewController *)source
 {
+    // In iOS7 the default presentingSourceViewController is the rootViewController, while the source VC, the one we actually want as the fromVC, is the source (who calls the presentViewController method)
+    self.sourceViewController = source;
     return self;
 }
 

--- a/Pod/Classes/URBNCarouselTransitionController.m
+++ b/Pod/Classes/URBNCarouselTransitionController.m
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, URBNCarouselTransitionState) {
 {
     UIViewController<URBNCarouselTransitioning> *vc = (UIViewController<URBNCarouselTransitioning> *)[transitionContext viewControllerForKey:key];
     
-    // Unless the view controller who called presentViewController sets definePresentationContext = YES; , the vc will be the rootViewController, who will not conform to the URBNTransitioning protocol.  In this case the trueContextViewController should be the source set by animationControllerForPresentedController.
+    // Unless the view controller who called presentViewController sets definePresentationContext = YES; (on iPhone, +iOS8 , the vc will be the rootViewController, who will not conform to the URBNTransitioning protocol.  In this case the trueContextViewController should be the source set by animationControllerForPresentedController.
     if (![vc conformsToProtocol:@protocol(URBNCarouselTransitioning)]) {
         vc = (UIViewController<URBNCarouselTransitioning> *)self.sourceViewController;
     }

--- a/URBNCarousel.podspec
+++ b/URBNCarousel.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'URBNCarousel'
-  s.version          = '0.8.4'
+  s.version          = ‘0.8.5’
   s.summary          = 'URBNCarousel is meant to be a convenience wrapper around UICollectionView / UITableView data management'
   s.homepage         = 'https://github.com/urbn/URBNCarousel'
   s.license          = 'MIT'

--- a/URBNCarousel.podspec
+++ b/URBNCarousel.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'URBNCarousel'
-  s.version          = ‘0.8.5’
+  s.version          = '0.8.5'
   s.summary          = 'URBNCarousel is meant to be a convenience wrapper around UICollectionView / UITableView data management'
   s.homepage         = 'https://github.com/urbn/URBNCarousel'
   s.license          = 'MIT'


### PR DESCRIPTION
I was finding a crash in iOS7 when transitioning between view controllers.  The presentingViewController gets set to the rootViewController, who doesn't conform to the URBNTransitioning protocol by default on an iPhone.  This fix sets the sourceViewController who calls the presentViewController method as the fromVC.  

Note: in iOS 8, the context can be changed by setting the definesPresentationContext property to YES on the presenting view controller.