### PR TITLE
Fixi os9 crash

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,3 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 pod 'URBNCarousel', :path => '..'
-pod 'URBNConvenience'

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,3 +1,4 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 pod 'URBNCarousel', :path => '..'
+pod 'URBNConvenience'

--- a/Pod/Classes/URBNScrollSyncCollectionView.m
+++ b/Pod/Classes/URBNScrollSyncCollectionView.m
@@ -55,33 +55,6 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-
-#pragma mark - Overrides
-- (void)setDelegate:(id <UICollectionViewDelegate>)delegate
-{
-    if (delegate != self) {
-        /**
-         So this is a fun one...
-         There appears to be some sort of internal optimization that caches the
-         selectors the delegate responds to up front. Because of this, if the
-         scrollView sets itself as the delegate before we have a passThroughDelegate
-         and the scrollView doesn't implement the optional delegate methods, setting the
-         passThoughDelegate later won't rebuild the cache (because internally the delegate
-         doesn't change) and consequently won't get forwarded events.
-         
-         The solution here is to nil out the delegate which resets the cache causing
-         it to rebuild every time we set a non-self delegate.
-         
-         For what it's worth, I don't believe this optimization used to exist because I've
-         used code like this before without issue.
-         */
-        self.passThroughDelegate = delegate;
-        [super setDelegate:nil];
-    }
-    
-    [super setDelegate:self];
-}
-
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
     if ([super respondsToSelector:aSelector]) {
@@ -112,7 +85,6 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
         NSLog(@"%@", exception);
     }
 }
-
 
 #pragma mark - Scroll Sync
 - (void)syncIndexPathChanged:(NSNotification *)note

--- a/Pod/Classes/URBNScrollSyncCollectionView.m
+++ b/Pod/Classes/URBNScrollSyncCollectionView.m
@@ -7,7 +7,6 @@
 //
 
 #import "URBNScrollSyncCollectionView.h"
-#import <URBNConvenience/URBNConvenience.h>
 
 const struct URBNScrollSyncCollectionViewIndexChangedNotification {
     __unsafe_unretained NSString * name;
@@ -49,7 +48,8 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
     NSAssert([self.collectionViewLayout isKindOfClass:[UICollectionViewFlowLayout class]], @"Cannot use URBNScrollSyncCollectionView with non flow layout");
     self.animateScrollSync = NO;
     self.delegate = self;
-    if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending) {
         [self setUpPassThroughDelegateWithDelegate:self.delegate];
     }
 }
@@ -59,9 +59,12 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+
+// TODO - update with less hacky code.  Rather than have both collection views listening to a posted notification, have them communicate where in the index path they should be when they transition back and forth.
 - (void)setUpPassThroughDelegateWithDelegate:(id <UICollectionViewDelegate>)delegate {
     if (delegate != self) {
         /**
+         // Comment by Demitri Miller
          So this is a fun one...
          There appears to be some sort of internal optimization that caches the
          selectors the delegate responds to up front. Because of this, if the
@@ -114,7 +117,6 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
         NSLog(@"%@", exception);
     }
 }
-
 
 #pragma mark - Scroll Sync
 - (void)syncIndexPathChanged:(NSNotification *)note

--- a/Pod/Classes/URBNScrollSyncCollectionView.m
+++ b/Pod/Classes/URBNScrollSyncCollectionView.m
@@ -7,6 +7,7 @@
 //
 
 #import "URBNScrollSyncCollectionView.h"
+#import <URBNConvenience/URBNConvenience.h>
 
 const struct URBNScrollSyncCollectionViewIndexChangedNotification {
     __unsafe_unretained NSString * name;
@@ -48,6 +49,9 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
     NSAssert([self.collectionViewLayout isKindOfClass:[UICollectionViewFlowLayout class]], @"Cannot use URBNScrollSyncCollectionView with non flow layout");
     self.animateScrollSync = NO;
     self.delegate = self;
+    if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+        [self setUpPassThroughDelegateWithDelegate:self.delegate];
+    }
 }
 
 - (void)dealloc
@@ -55,6 +59,31 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)setUpPassThroughDelegateWithDelegate:(id <UICollectionViewDelegate>)delegate {
+    if (delegate != self) {
+        /**
+         So this is a fun one...
+         There appears to be some sort of internal optimization that caches the
+         selectors the delegate responds to up front. Because of this, if the
+         scrollView sets itself as the delegate before we have a passThroughDelegate
+         and the scrollView doesn't implement the optional delegate methods, setting the
+         passThoughDelegate later won't rebuild the cache (because internally the delegate
+         doesn't change) and consequently won't get forwarded events.
+
+         The solution here is to nil out the delegate which resets the cache causing
+         it to rebuild every time we set a non-self delegate.
+
+         For what it's worth, I don't believe this optimization used to exist because I've
+         used code like this before without issue.
+         */
+        self.passThroughDelegate = delegate;
+        [super setDelegate:nil];
+    }
+
+    [super setDelegate:self];
+}
+
+#pragma mark - Overrides
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
     if ([super respondsToSelector:aSelector]) {
@@ -85,6 +114,7 @@ const struct URBNScrollSyncCollectionViewIndexChangedNotification URBNScrollSync
         NSLog(@"%@", exception);
     }
 }
+
 
 #pragma mark - Scroll Sync
 - (void)syncIndexPathChanged:(NSNotification *)note


### PR DESCRIPTION
The purpose of this PR is to fix a crash that was in URBNScrollSynCollectionView in iOS9.  The override delegate setter was attempting to reference a delegate that had already been released.  This is likely due to more optimizations with delegates and their selectors.  In any case this syncing technique needs to be changed to a method that is less reliant on delegates and notifications.

- added a system check for the delegate override